### PR TITLE
Feature nxp 27485 probes endpoint implementation

### DIFF
--- a/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/distribution/SimplifiedServerInfoWriter.java
+++ b/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/distribution/SimplifiedServerInfoWriter.java
@@ -45,7 +45,6 @@ public class SimplifiedServerInfoWriter extends AbstractJsonWriter<SimplifiedSer
 
     @Override
     public void write(SimplifiedServerInfo entity, JsonGenerator jg) throws IOException {
-        jg.useDefaultPrettyPrinter();
         jg.writeStartObject();
         jg.writeStringField(Environment.PRODUCT_NAME, entity.getApplicationName());
         jg.writeStringField(Environment.PRODUCT_VERSION, entity.getApplicationVersion());

--- a/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/probes/ProbeInfoListWriter.java
+++ b/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/probes/ProbeInfoListWriter.java
@@ -1,0 +1,42 @@
+/*
+ * (C) Copyright 2019 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Nour Al Kotob
+ */
+
+package org.nuxeo.rest.management.probes;
+
+import static org.nuxeo.ecm.core.io.registry.reflect.Instantiations.SINGLETON;
+import static org.nuxeo.ecm.core.io.registry.reflect.Priorities.REFERENCE;
+
+import org.nuxeo.ecm.core.io.marshallers.json.DefaultListJsonWriter;
+import org.nuxeo.ecm.core.io.registry.reflect.Setup;
+import org.nuxeo.ecm.core.management.api.ProbeInfo;
+
+/**
+ * see {@link DefaultListJsonWriter}
+ *
+ * @since 11.1
+ */
+@Setup(mode = SINGLETON, priority = REFERENCE)
+public class ProbeInfoListWriter extends DefaultListJsonWriter<ProbeInfo> {
+
+    public static final String ENTITY_PROBES_LIST = "probes";
+
+    public ProbeInfoListWriter() {
+        super(ENTITY_PROBES_LIST, ProbeInfo.class);
+    }
+}

--- a/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/probes/ProbeInfoWriter.java
+++ b/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/probes/ProbeInfoWriter.java
@@ -1,0 +1,77 @@
+/*
+ * (C) Copyright 2019 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Nour Al Kotob
+ */
+
+package org.nuxeo.rest.management.probes;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static org.nuxeo.ecm.core.io.registry.reflect.Instantiations.SINGLETON;
+import static org.nuxeo.ecm.core.io.registry.reflect.Priorities.REFERENCE;
+
+import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+import org.nuxeo.ecm.core.io.marshallers.json.AbstractJsonWriter;
+import org.nuxeo.ecm.core.io.registry.reflect.Setup;
+import org.nuxeo.ecm.core.management.api.ProbeInfo;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+
+/**
+ * see {@link AbstractJsonWriter}
+ *
+ * @since 11.1
+ */
+@Setup(mode = SINGLETON, priority = REFERENCE)
+public class ProbeInfoWriter extends AbstractJsonWriter<ProbeInfo> {
+
+    @Override
+    public void write(ProbeInfo entity, JsonGenerator jg) throws IOException {
+        jg.writeStartObject();
+
+        jg.writeStringField("name", entity.getShortcutName());
+
+        writeEntityField("status", entity.getStatus(), jg);
+
+        jg.writeObjectFieldStart("history");
+        jg.writeStringField("lastRun", formatDate(entity.getLastRunnedDate()));
+        jg.writeStringField("lastSuccess", formatDate(entity.getLastSucceedDate()));
+        jg.writeStringField("lastFail", formatDate(entity.getLastFailedDate()));
+        jg.writeEndObject();
+
+        jg.writeObjectFieldStart("counts");
+        jg.writeNumberField("run", entity.getRunnedCount());
+        jg.writeNumberField("success", entity.getSucceedCount());
+        jg.writeNumberField("failure", entity.getFailedCount());
+        jg.writeEndObject();
+
+        jg.writeNumberField("time", entity.getLastDuration());
+
+        jg.writeEndObject();
+    }
+
+    protected String formatDate(Date date) {
+        if (date != null) {
+            ZonedDateTime zdt = ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
+            return ISO_LOCAL_DATE_TIME.format(zdt);
+        }
+        return null;
+    }
+}

--- a/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/probes/ProbeStatusWriter.java
+++ b/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/probes/ProbeStatusWriter.java
@@ -1,0 +1,58 @@
+/*
+ * (C) Copyright 2019 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Nour Al Kotob
+ */
+
+package org.nuxeo.rest.management.probes;
+
+import static org.nuxeo.ecm.core.io.registry.reflect.Instantiations.SINGLETON;
+import static org.nuxeo.ecm.core.io.registry.reflect.Priorities.REFERENCE;
+
+import java.io.IOException;
+import java.util.Map.Entry;
+
+import org.nuxeo.ecm.core.io.marshallers.json.AbstractJsonWriter;
+import org.nuxeo.ecm.core.io.registry.reflect.Setup;
+import org.nuxeo.ecm.core.management.api.ProbeStatus;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+
+/**
+ * see {@link AbstractJsonWriter}
+ *
+ * @since 11.1
+ */
+@Setup(mode = SINGLETON, priority = REFERENCE)
+public class ProbeStatusWriter extends AbstractJsonWriter<ProbeStatus> {
+
+    @Override
+    public void write(ProbeStatus entity, JsonGenerator jg) throws IOException {
+        jg.useDefaultPrettyPrinter();
+        jg.writeStartObject();
+
+        jg.writeBooleanField("neverExecuted", entity.isNeverExecuted());
+        jg.writeBooleanField("success", entity.isSuccess());
+
+        jg.writeObjectFieldStart("infos");
+        for (Entry<String, String> e : entity.getInfos().entrySet()) {
+            jg.writeStringField(e.getKey(), e.getValue());
+        }
+        jg.writeEndObject();
+
+        jg.writeEndObject();
+    }
+}

--- a/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/probes/ProbeStatusWriter.java
+++ b/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/probes/ProbeStatusWriter.java
@@ -41,7 +41,6 @@ public class ProbeStatusWriter extends AbstractJsonWriter<ProbeStatus> {
 
     @Override
     public void write(ProbeStatus entity, JsonGenerator jg) throws IOException {
-        jg.useDefaultPrettyPrinter();
         jg.writeStartObject();
 
         jg.writeBooleanField("neverExecuted", entity.isNeverExecuted());

--- a/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/probes/ProbesObject.java
+++ b/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/probes/ProbesObject.java
@@ -1,0 +1,81 @@
+/*
+ * (C) Copyright 2019 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Nour Al Kotob
+ */
+
+package org.nuxeo.rest.management.probes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.nuxeo.ecm.core.management.api.ProbeInfo;
+import org.nuxeo.ecm.core.management.api.ProbeManager;
+import org.nuxeo.ecm.webengine.model.WebObject;
+import org.nuxeo.ecm.webengine.model.impl.DefaultObject;
+import org.nuxeo.runtime.api.Framework;
+
+/**
+ * @since 11.1
+ */
+@WebObject(type = "probes")
+public class ProbesObject extends DefaultObject {
+
+    /**
+     * Gets the infos of a specific probe.
+     *
+     * @param probeName the shortcut name of the probe to get
+     * @return a {@link ProbeInfo}
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("{probeName}")
+    public ProbeInfo doGet(@PathParam("probeName") String probeName) {
+        return Framework.getService(ProbeManager.class).getProbeInfo(probeName);
+    }
+
+    /**
+     * Gets all the infos of all probes.
+     *
+     * @return a list of all {@link ProbeInfo}
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<ProbeInfo> doGet() {
+        return new ArrayList<>(Framework.getService(ProbeManager.class).getAllProbeInfos());
+    }
+
+    /**
+     * Launches a specific probe.
+     *
+     * @param probeName the shortcut name of the probe to launch
+     * @return the result of the probe in a {@link ProbeInfo}
+     */
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("{probeName}")
+    public ProbeInfo launch(@PathParam("probeName") String probeName) {
+        return Framework.getService(ProbeManager.class).runProbe(probeName);
+    }
+
+}

--- a/nuxeo-management-rest-api/src/main/resources/META-INF/MANIFEST.MF
+++ b/nuxeo-management-rest-api/src/main/resources/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-SymbolicName: org.nuxeo.rest.management;singleton:=true
 Bundle-Version: 1.0.0
 Bundle-Vendor: Nuxeo
 Nuxeo-WebModule: org.nuxeo.rest.management.ManagementModule;name=management;host=management
-Nuxeo-Component: OSGI-INF/SimplifiedServerInfoWriter-contrib.xml
+Nuxeo-Component: OSGI-INF/rest-management-marshallers-contrib.xml

--- a/nuxeo-management-rest-api/src/main/resources/OSGI-INF/rest-management-marshallers-contrib.xml
+++ b/nuxeo-management-rest-api/src/main/resources/OSGI-INF/rest-management-marshallers-contrib.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component name="org.nuxeo.rest.management.marshallers">
   <extension target="org.nuxeo.ecm.core.io.MarshallerRegistry" point="marshallers">
+    <register class="org.nuxeo.rest.management.probes.ProbeInfoWriter" enable="true" />
+    <register class="org.nuxeo.rest.management.probes.ProbeInfoListWriter" enable="true" />
+    <register class="org.nuxeo.rest.management.probes.ProbeStatusWriter" enable="true" />
     <register class="org.nuxeo.rest.management.distribution.SimplifiedServerInfoWriter" enable="true" />
   </extension>
 </component>

--- a/nuxeo-management-rest-api/src/test/java/org/nuxeo/rest/management/ManagementBaseTest.java
+++ b/nuxeo-management-rest-api/src/test/java/org/nuxeo/rest/management/ManagementBaseTest.java
@@ -37,7 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @since 11.1
  */
 @RunWith(FeaturesRunner.class)
-@Features(ManagementFeature.class)
+@Features(RestManagementFeature.class)
 public abstract class ManagementBaseTest {
 
     protected static final String ADMINISTRATOR = "Administrator";

--- a/nuxeo-management-rest-api/src/test/java/org/nuxeo/rest/management/RESTManagementFeature.java
+++ b/nuxeo-management-rest-api/src/test/java/org/nuxeo/rest/management/RESTManagementFeature.java
@@ -31,5 +31,5 @@ import org.nuxeo.runtime.test.runner.RunnerFeature;
 @Deploy("org.nuxeo.ecm.platform.web.common")
 @Deploy("org.nuxeo.rest.management")
 @Deploy("org.nuxeo.rest.management:OSGI-INF/test-webengine-servletcontainer-contrib.xml")
-public class ManagementFeature implements RunnerFeature {
+public class RestManagementFeature implements RunnerFeature {
 }

--- a/nuxeo-management-rest-api/src/test/java/org/nuxeo/rest/management/TestProbesObject.java
+++ b/nuxeo-management-rest-api/src/test/java/org/nuxeo/rest/management/TestProbesObject.java
@@ -1,0 +1,117 @@
+/*
+ * (C) Copyright 2019 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Thomas Roger
+ *     Nour Al Kotob
+ */
+
+package org.nuxeo.rest.management;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Test;
+import org.nuxeo.ecm.core.io.marshallers.json.JsonAssert;
+import org.nuxeo.jaxrs.test.CloseableClientResponse;
+import org.nuxeo.runtime.test.runner.Deploy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * @since 11.1
+ */
+@Deploy("org.nuxeo.ecm.core.management")
+public class TestProbesObject extends ManagementBaseTest {
+
+    private static final String FAILURE_COUNT = "failure";
+
+    private static final String SUCCESS_COUNT = "success";
+
+    protected static final String RUN_COUNT = "run";
+
+    protected static final String COUNTS = "counts";
+
+    protected static final String ADMINISTRATIVE_STATUS = "administrativeStatus";
+
+    protected static final String STATUS_INFOS = "infos";
+
+    protected static final String STATUS_SUCCESS = SUCCESS_COUNT;
+
+    protected static final String NAME = "name";
+
+    public static final String PATH = "site/management/probes";
+
+    @Test
+    public void testAllProbes() throws IOException {
+        try (CloseableClientResponse response = httpClientRule.get(PATH)) {
+            assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+            JsonNode node = mapper.readTree(response.getEntityInputStream());
+            JsonAssert jAssert = JsonAssert.on(node.toString());
+            jAssert.get("entity-type").isEquals("probes");
+            JsonAssert jProbeArray = jAssert.get("entries");
+
+            JsonAssert jProbe = jProbeArray.get(0);
+            testProbeInfo(jProbe);
+        }
+    }
+
+    @Test
+    public void testProbe() throws IOException {
+        try (CloseableClientResponse response = httpClientRule.get(PATH + "/" + ADMINISTRATIVE_STATUS)) {
+            assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+            JsonNode node = mapper.readTree(response.getEntityInputStream());
+            JsonAssert jAssert = JsonAssert.on(node.toString());
+            testProbeInfo(jAssert);
+        }
+    }
+
+    @Test
+    public void testLaunchProbe() throws IOException {
+        int runCount;
+        try (CloseableClientResponse response = httpClientRule.get(PATH + "/" + ADMINISTRATIVE_STATUS)) {
+            assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+            JsonNode node = mapper.readTree(response.getEntityInputStream());
+            runCount = node.get(COUNTS).get(RUN_COUNT).asInt();
+        }
+        try (CloseableClientResponse response = httpClientRule.post(PATH + "/" + ADMINISTRATIVE_STATUS, null)) {
+            assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+            JsonNode node = mapper.readTree(response.getEntityInputStream());
+            JsonAssert jAssert = JsonAssert.on(node.toString());
+            testProbeInfo(jAssert);
+            assertEquals(runCount + 1L, node.get(COUNTS).get(RUN_COUNT).asInt());
+        }
+    }
+
+    protected void testProbeInfo(JsonAssert jProbe) throws IOException {
+        jProbe.get(NAME).notNull();
+        jProbe.get("status").get(STATUS_SUCCESS).notNull();
+        jProbe.get("status").get(STATUS_INFOS).notNull();
+
+        JsonAssert jHistory = jProbe.get("history");
+        jHistory.has("lastRun");
+        jHistory.has("lastSuccess");
+        jHistory.has("lastFail");
+
+        JsonAssert jCounts = jProbe.get(COUNTS);
+        jCounts.has(RUN_COUNT);
+        jCounts.has(SUCCESS_COUNT);
+        jCounts.has(FAILURE_COUNT);
+        jProbe.get("time").notNull();
+    }
+}


### PR DESCRIPTION
Adding 2 get methodes (single and all)
Adding 1 post method (launch a probe) that could also be a get since we are just giving a probe name as param.