### PR TITLE
NXP-27672: implement the workmanager/runworkinfailure endpoint

### DIFF
--- a/nuxeo-management-rest-api/pom.xml
+++ b/nuxeo-management-rest-api/pom.xml
@@ -22,6 +22,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.nuxeo.ecm.automation</groupId>
+      <artifactId>nuxeo-automation-features</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.nuxeo.ecm.core</groupId>
       <artifactId>nuxeo-core-management</artifactId>
     </dependency>
@@ -60,7 +65,7 @@
       <artifactId>nuxeo-automation-test</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>org.nuxeo.ecm.platform</groupId>
       <artifactId>nuxeo-platform-tag-core</artifactId>

--- a/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/ManagementModule.java
+++ b/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/ManagementModule.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.nuxeo.ecm.webengine.app.WebEngineExceptionMapper;
 import org.nuxeo.ecm.webengine.app.WebEngineModule;
 import org.nuxeo.ecm.webengine.jaxrs.coreiodelegate.JsonCoreIODelegate;
+import org.nuxeo.ecm.webengine.model.io.BlobWriter;
 
 /**
  * @since 11.1
@@ -43,6 +44,7 @@ public class ManagementModule extends WebEngineModule {
         Set<Object> result = new HashSet<>();
         result.add(new JsonCoreIODelegate());
         result.add(new WebEngineExceptionMapper());
+        result.add(new BlobWriter());
         return result;
     }
 }

--- a/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/work/manager/WorkManagerObject.java
+++ b/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/work/manager/WorkManagerObject.java
@@ -1,0 +1,69 @@
+/*
+ * (C) Copyright 2019 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Nour Al Kotob
+ */
+package org.nuxeo.rest.management.work.manager;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.commons.lang3.StringUtils;
+import org.nuxeo.ecm.automation.AutomationService;
+import org.nuxeo.ecm.automation.OperationContext;
+import org.nuxeo.ecm.automation.OperationException;
+import org.nuxeo.ecm.automation.core.operations.services.workmanager.WorkManagerRunWorkInFailure;
+import org.nuxeo.ecm.core.api.Blob;
+import org.nuxeo.ecm.webengine.model.WebObject;
+import org.nuxeo.ecm.webengine.model.impl.DefaultObject;
+import org.nuxeo.runtime.api.Framework;
+
+/**
+ * @since 11.1
+ */
+@WebObject(type = "workmanager")
+public class WorkManagerObject extends DefaultObject {
+
+    public static final String TIMEOUT_SECONDS_PARAM_KEY = "timeoutSeconds";
+
+    /**
+     * Executes Works stored in the dead letter queue (DLQ) after failure.
+     *
+     * @param timeoutSeconds a timeout for the works to end.
+     * @return The result of the rerun
+     */
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("runworksinfailure")
+    public Blob launch(@FormParam(TIMEOUT_SECONDS_PARAM_KEY) String timeoutSeconds) throws OperationException {
+        AutomationService automationService = Framework.getService(AutomationService.class);
+        try (OperationContext operationCtx = new OperationContext(this.ctx.getCoreSession())) {
+            Map<String, Serializable> params = new HashMap<>();
+            if (StringUtils.isNotBlank(timeoutSeconds)) {
+                params.put(TIMEOUT_SECONDS_PARAM_KEY, timeoutSeconds);
+            }
+
+            return (Blob) automationService.run(operationCtx, WorkManagerRunWorkInFailure.ID, params);
+        }
+    }
+}

--- a/nuxeo-management-rest-api/src/test/java/org/nuxeo/rest/management/TestWorkManagerObject.java
+++ b/nuxeo-management-rest-api/src/test/java/org/nuxeo/rest/management/TestWorkManagerObject.java
@@ -1,0 +1,55 @@
+/*
+ * (C) Copyright 2019 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Nour Al Kotob
+ */
+package org.nuxeo.rest.management;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.nuxeo.ecm.automation.test.AutomationFeature;
+import org.nuxeo.jaxrs.test.CloseableClientResponse;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+import org.nuxeo.runtime.test.runner.LogCaptureFeature;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * @since 11.1
+ */
+@RunWith(FeaturesRunner.class)
+@Features({ AutomationFeature.class, LogCaptureFeature.class })
+@Deploy("org.nuxeo.rest.management:OSGI-INF/test-work-dead-letter-queue.xml")
+public class TestWorkManagerObject extends ManagementBaseTest {
+
+    @Test
+    public void shouldRunWorksInFailure() throws IOException {
+        String path = "site/management/workmanager/runworksinfailure";
+        try (CloseableClientResponse response = httpClientRule.post(path, null)) {
+            assertEquals(SC_OK, response.getStatus());
+            JsonNode result = mapper.readTree(response.getEntityInputStream());
+            assertEquals(0, result.get("total").asInt());
+            assertEquals(0, result.get("success").asInt());
+        }
+    }
+}

--- a/nuxeo-management-rest-api/src/test/resources/OSGI-INF/test-work-dead-letter-queue.xml
+++ b/nuxeo-management-rest-api/src/test/resources/OSGI-INF/test-work-dead-letter-queue.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.rest.management.stream.default.config.test" version="1.0">
+  <require>org.nuxeo.ecm.core.work.service</require>
+
+  <extension target="org.nuxeo.runtime.stream.service" point="logConfig">
+    <logConfig name="default" />
+  </extension>
+
+</component>


### PR DESCRIPTION
Works in tests.
Fails on my local platform because I don't have `WorkManagerImpl.DEAD_LETTER_QUEUE_CODEC`
