### PR TITLE
NXP-27370: enhance user and port filtering

### DIFF
--- a/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/ManagementRoot.java
+++ b/nuxeo-management-rest-api/src/main/java/org/nuxeo/rest/management/ManagementRoot.java
@@ -19,18 +19,11 @@
 
 package org.nuxeo.rest.management;
 
-import static java.lang.Boolean.TRUE;
-import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
-import org.nuxeo.ecm.core.api.NuxeoException;
-import org.nuxeo.ecm.core.api.NuxeoPrincipal;
 import org.nuxeo.ecm.webengine.model.WebObject;
 import org.nuxeo.ecm.webengine.model.impl.ModuleRoot;
-import org.nuxeo.runtime.api.Framework;
 
 /**
  * @since 11.1
@@ -39,31 +32,9 @@ import org.nuxeo.runtime.api.Framework;
 @WebObject(type = "management")
 public class ManagementRoot extends ModuleRoot {
 
-    public static final String MANAGEMENT_API_USER_PROPERTY = "org.nuxeo.rest.management.user";
-
     @Path("{path}")
     public Object route(@PathParam("path") String path) {
-        // check if the Management API is enabled on this request
-        verifyEnabled();
-
-        // check if the user can access the Management API
-        verifyUser();
-
         return newObject(path);
-    }
-
-    protected void verifyEnabled() {
-        if (!TRUE.equals(ManagementFilter.API_ENABLED.get())) {
-            throw new NuxeoException("Requested path doesn't exist", SC_NOT_FOUND);
-        }
-    }
-
-    protected void verifyUser() {
-        NuxeoPrincipal principal = getContext().getPrincipal();
-        String managementUser = Framework.getProperty(MANAGEMENT_API_USER_PROPERTY);
-        if (principal == null || !(principal.getName().equals(managementUser) || principal.isAdministrator())) {
-            throw new NuxeoException(SC_FORBIDDEN);
-        }
     }
 
 }

--- a/nuxeo-management-rest-api/src/test/java/org/nuxeo/rest/management/TestJWTAuthentication.java
+++ b/nuxeo-management-rest-api/src/test/java/org/nuxeo/rest/management/TestJWTAuthentication.java
@@ -90,7 +90,7 @@ public class TestJWTAuthentication {
                                                                      .build();
         unauthorizedHttpClientRule.starting();
 
-        Framework.getProperties().put(ManagementRoot.MANAGEMENT_API_USER_PROPERTY, "transient/foo");
+        Framework.getProperties().put(ManagementFilter.MANAGEMENT_API_USER_PROPERTY, "transient/foo");
     }
 
     @After
@@ -98,7 +98,7 @@ public class TestJWTAuthentication {
         authorizedHttpClientRule.finished();
         unauthorizedHttpClientRule.finished();
 
-        Framework.getProperties().remove(ManagementRoot.MANAGEMENT_API_USER_PROPERTY);
+        Framework.getProperties().remove(ManagementFilter.MANAGEMENT_API_USER_PROPERTY);
     }
 
     @Test


### PR DESCRIPTION
Hello,

I was reviewing the Management Rest API and testing the different endpoint. I saw several problems especially when running on port 9090:

 * `GET /nuxeo/site/management` return a 405 which means to a potential attacker that the management API is installed. 
 * `GET /nuxeo/site/management/*` return a 404 which is good, but it also renders the stack trace which first exposes the fact that the API is installed, but is also very expensive, leading to potential DoS.
 * When the user is not well identified, we have the same stack trace. 
 * When not using the `Accept: application/json` the stack trace is not even rendered, but it produces lots of useless logs which can quickly fill the disk and also be exploited by an attcker)

So, here is a proposal for a potential fix to these problems, take it or lose it :-) . It also gets rid of the `ThreadLocal` in the filter by directly detecting the outcome of the filter, that way we do not even hit the WebEngine servlet. 